### PR TITLE
Fix mobile menu opening on mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -222,6 +222,11 @@ const ControllerNode = ({ shape, items, sections, anchor, title, active, setActi
     bottom: "bottom-[calc(100%+16px)] left-1/2 -translate-x-1/2",
   }[anchor];
 
+  // On mobile, render menus fixed at the bottom center so they never clip off-screen
+  const containerPos = isMobile
+    ? "fixed bottom-4 left-1/2 -translate-x-1/2"
+    : `absolute ${panelPos}`;
+
   const handlers = isMobile
     ? {
         onClick: (e) => {
@@ -249,7 +254,7 @@ const ControllerNode = ({ shape, items, sections, anchor, title, active, setActi
 
       <AnimatePresence>
         {open && (
-          <div className={`absolute ${panelPos} pointer-events-none`}>
+          <div className={`${containerPos} pointer-events-none`}>
             <Panel items={items} sections={sections} mobile={isMobile} title={title} />
           </div>
         )}


### PR DESCRIPTION
## Summary
- keep mobile menus centered at the bottom of the screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1e88c2ac8832ba6ddae5f29456285